### PR TITLE
NetworkChangedEvent => ChainChangedEvent as NetworkChanged is deprecated

### DIFF
--- a/MetaMask.Blazor/MetaMaskService.cs
+++ b/MetaMask.Blazor/MetaMaskService.cs
@@ -22,7 +22,7 @@ namespace MetaMask.Blazor
         private readonly Lazy<Task<IJSObjectReference>> moduleTask;
 
         public static event Func<string, Task>? AccountChangedEvent;
-        public static event Func<(int, Chain), Task>? NetworkChangedEvent;
+        public static event Func<(int, Chain), Task>? ChainChangedEvent;
         //public static event Func<Task>? ConnectEvent;
         //public static event Func<Task>? DisconnectEvent;
 
@@ -222,11 +222,11 @@ namespace MetaMask.Blazor
         }
 
         [JSInvokable()]
-        public static async Task OnNetworkChanged(string chainhex)
+        public static async Task OnChainChanged(string chainhex)
         {
-            if (NetworkChangedEvent != null)
+            if (ChainChangedEvent != null)
             {
-                await NetworkChangedEvent.Invoke(ChainHexToChainResponse(chainhex));
+                await ChainChangedEvent.Invoke(ChainHexToChainResponse(chainhex));
             }
         }
 

--- a/MetaMask.Blazor/wwwroot/metaMaskJsInterop.js
+++ b/MetaMask.Blazor/wwwroot/metaMaskJsInterop.js
@@ -56,8 +56,8 @@ export async function listenToChangeEvents() {
             DotNet.invokeMethodAsync('MetaMask.Blazor', 'OnAccountsChanged', accounts[0]);
         });
 
-        ethereum.on("networkChanged", function (networkId) {
-            DotNet.invokeMethodAsync('MetaMask.Blazor', 'OnNetworkChanged', networkId);
+        ethereum.on("chainChanged", function (chainId) {
+            DotNet.invokeMethodAsync('MetaMask.Blazor', 'OnChainChanged', chainId);
         });
     }
 }


### PR DESCRIPTION
NetworkChangedEvent => ChainChangedEvent as NetworkChanged is deprecated  and when using a chain other than eth cause problems because the code was treating netword id as HEX related to #1 